### PR TITLE
Add better unit tests for job-status-recorder

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,10 +26,20 @@ import (
 	"github.com/streadway/amqp"
 )
 
+// Messenger defines an interface for handling AMQP operations. This is the
+// subset of functionality needed by job-status-recorder.
+type Messenger interface {
+	AddConsumer(string, string, string, string, messaging.MessageHandler)
+	Close()
+	Listen()
+	Publish(string, []byte) error
+	SetupPublishing(string) error
+}
+
 // JobStatusRecorder contains the application state for job-status-recorder
 type JobStatusRecorder struct {
 	cfg        *viper.Viper
-	amqpClient *messaging.Client
+	amqpClient Messenger
 	db         *sql.DB
 }
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cyverse-de/logcabin"
 	"github.com/cyverse-de/messaging"
 	"github.com/cyverse-de/version"
-	"github.com/golang/protobuf/proto"
 	_ "github.com/lib/pq"
 	"github.com/spf13/viper"
 	"github.com/streadway/amqp"
@@ -65,13 +64,9 @@ func (r *JobStatusRecorder) insert(state, invID, msg, host, ip string, sentOn in
 }
 
 func (r *JobStatusRecorder) pingHandler(delivery amqp.Delivery) {
-	if err := delivery.Ack(false); err != nil {
-		logcabin.Error.Print(err)
-	}
-
 	logcabin.Info.Println("Received ping")
 
-	out, err := proto.Marshal(&ping.Pong{})
+	out, err := json.Marshal(&ping.Pong{})
 	if err != nil {
 		logcabin.Error.Print(err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -252,7 +252,10 @@ func TestMsg(t *testing.T) {
 		{"State", "InvocationID", "Message", "127.0.0.1", "127.0.0.1", nowstr},
 		{"", "InvocationID", "Message", "127.0.0.1", "127.0.0.1", nowstr},
 		{"State", "", "Message", "127.0.0.1", "127.0.0.1", nowstr},
+		{"State", "InvocationID", "", "127.0.0.1", "127.0.0.1", nowstr},
 		{"State", "InvocationID", "Message", "", "0.0.0.0", nowstr},
+		{"State", "InvocationID", "Message", "localhost", "localhost", nowstr},
+		{"State", "InvocationID", "Message", "barf", "barf", nowstr},
 		{"State", "InvocationID", "Message", "127.0.0.1", "127.0.0.1", ""},
 	}
 
@@ -294,10 +297,24 @@ func TestMsg(t *testing.T) {
 		if tc.Sender == "" {
 			tc.Sender = "0.0.0.0"
 		}
+
 		n := now
 		if tc.SentOn == "" {
 			n = 0
 		}
+
+		if tc.Message == "" {
+			tc.Message = "UNKNOWN"
+		}
+
+		if tc.Sender == "localhost" {
+			tc.Sender = "::1"
+		}
+
+		if tc.Sender == "barf" {
+			tc.Sender = ""
+		}
+
 		mock.ExpectExec("INSERT INTO job_status_updates").
 			WithArgs(tc.InvocationID, tc.Message, tc.State, tc.Sender, tc.SenderAddr, n).
 			WillReturnResult(result)

--- a/main_test.go
+++ b/main_test.go
@@ -3,15 +3,17 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
-	"net"
+	"errors"
+	"fmt"
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/cyverse-de/configurate"
 	"github.com/cyverse-de/messaging"
 	"github.com/cyverse-de/model"
+	"github.com/johnworth/events/ping"
 	"github.com/spf13/viper"
 	"github.com/streadway/amqp"
 )
@@ -55,144 +57,262 @@ func inittests(t *testing.T) {
 	}
 }
 
-func TestInsert(t *testing.T) {
-	if !shouldrun() {
-		return
+func TestNew(t *testing.T) {
+	n := New(cfg)
+
+	if n == nil {
+		t.Error("New returned nil")
 	}
+
+	if n.cfg != cfg {
+		t.Error("Config objects did not match")
+	}
+}
+
+func TestInsert(t *testing.T) {
 	inittests(t)
 	app := New(cfg)
-	app.db = initdb(t)
-	defer app.db.Close()
-	n := time.Now().UnixNano() / int64(time.Millisecond)
-	actual, err := app.insert("RUNNING", "test-invocation-id", "test", "localhost", "127.0.0.1", n)
+	db, mock, err := sqlmock.New()
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("an error '%s' was encountered when creating the mock database", err)
 	}
-	rowCount, err := actual.RowsAffected()
+	defer db.Close()
+	app.db = db
+
+	var lastInsertID int64
+	result := sqlmock.NewResult(lastInsertID, 1)
+	mock.ExpectExec("INSERT INTO job_status_updates").
+		WithArgs("invID", "message", "state", "host", "ip", 0).
+		WillReturnResult(result)
+
+	_, err = app.insert("state", "invID", "message", "ip", "host", 0)
 	if err != nil {
-		t.Error(err)
+		t.Errorf("error was not expected updating job_status_updates: %s", err)
 	}
-	rows, err := app.db.Query("select status, message, sent_from, sent_from_hostname, sent_on from job_status_updates where external_id = 'test-invocation-id'")
-	if err != nil {
-		t.Error(err)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations inserting job_status_updates")
 	}
-	defer rows.Close()
-	var (
-		status, message, sentFromHostname string
-		sentOn                            int64
-		sentFrom                          string
-	)
-	for rows.Next() {
-		err = rows.Scan(&status, &message, &sentFrom, &sentFromHostname, &sentOn)
-		if err != nil {
-			t.Error(err)
-		}
-		if status != "RUNNING" {
-			t.Errorf("status was %s instead of RUNNING", status)
-		}
-		if message != "test" {
-			t.Errorf("message was %s instead of 'test'", message)
-		}
-		if sentFrom != "127.0.0.1" {
-			t.Errorf("sentFrom was %s instead of '127.0.0.1'", sentFrom)
-		}
-		if sentFromHostname != "localhost" {
-			t.Errorf("sentFromHostname was %s instead of 'localhost'", sentFromHostname)
-		}
-		if n != sentOn {
-			t.Errorf("sentOn was %d instead of %d", sentOn, n)
-		}
+}
+
+type MockConsumer struct {
+	exchange     string
+	exchangeType string
+	queue        string
+	key          string
+	handler      messaging.MessageHandler
+}
+
+type MockMessage struct {
+	key string
+	msg []byte
+}
+
+type MockMessenger struct {
+	consumers         []MockConsumer
+	publishedMessages []MockMessage
+	publishTo         []string
+	publishError      bool
+}
+
+func (m *MockMessenger) Close()  {}
+func (m *MockMessenger) Listen() {}
+
+func (m *MockMessenger) AddConsumer(exchange, exchangeType, queue, key string, handler messaging.MessageHandler) {
+	m.consumers = append(m.consumers, MockConsumer{
+		exchange:     exchange,
+		exchangeType: exchangeType,
+		queue:        queue,
+		key:          key,
+		handler:      handler,
+	})
+}
+
+func (m *MockMessenger) Publish(key string, msg []byte) error {
+	if m.publishError {
+		return errors.New("publish error")
 	}
-	err = rows.Err()
-	if err != nil {
-		t.Error(err)
+	m.publishedMessages = append(m.publishedMessages, MockMessage{key: key, msg: msg})
+	return nil
+}
+
+func (m *MockMessenger) SetupPublishing(exchange string) error {
+
+	m.publishTo = append(m.publishTo, exchange)
+	return nil
+}
+
+func TestPingHandler(t *testing.T) {
+	inittests(t)
+	app := New(cfg)
+	app.amqpClient = &MockMessenger{
+		publishedMessages: make([]MockMessage, 0),
 	}
-	if rowCount != 1 {
-		t.Errorf("RowsAffected() should have returned 1: %d", rowCount)
+	d := amqp.Delivery{}
+
+	app.pingHandler(d)
+	mm := app.amqpClient.(*MockMessenger)
+	numMessages := len(mm.publishedMessages)
+	if numMessages != 1 {
+		t.Errorf("number of published messages was not 1: %d", numMessages)
 	}
-	_, err = app.db.Exec("DELETE FROM job_status_updates")
-	if err != nil {
-		t.Error(err)
+	msg := mm.publishedMessages[0]
+	if msg.key != pongKey {
+		t.Errorf("routing key was %s instead of %s", msg.key, pongKey)
+	}
+	pong := &ping.Pong{}
+	if err := json.Unmarshal(msg.msg, pong); err != nil {
+		t.Errorf("error unmarshalling message: %s", err)
+	}
+
+	app.amqpClient = &MockMessenger{
+		publishedMessages: make([]MockMessage, 0),
+		publishError:      true,
+	}
+	app.pingHandler(d)
+	mm = app.amqpClient.(*MockMessenger)
+	numMessages = len(mm.publishedMessages)
+	if numMessages != 0 {
+		t.Errorf("number of published messages was not 0: %d", numMessages)
+	}
+}
+
+func TestEventsHandler(t *testing.T) {
+	inittests(t)
+	app := New(cfg)
+	app.amqpClient = &MockMessenger{
+		publishedMessages: make([]MockMessage, 0),
+	}
+	d := amqp.Delivery{
+		RoutingKey: pingKey,
+	}
+	app.eventsHandler(d)
+	mm := app.amqpClient.(*MockMessenger)
+	numMessages := len(mm.publishedMessages)
+	if numMessages != 1 {
+		t.Errorf("number of published messages was not 1: %d", numMessages)
+	}
+	msg := mm.publishedMessages[0]
+	if msg.key != pongKey {
+		t.Errorf("routing key was %s instead of %s", msg.key, pongKey)
+	}
+	pong := &ping.Pong{}
+	if err := json.Unmarshal(msg.msg, pong); err != nil {
+		t.Errorf("error unmarshalling message: %s", err)
+	}
+
+	d = amqp.Delivery{
+		RoutingKey: "not-a-key",
+	}
+	app.eventsHandler(d)
+	mm = app.amqpClient.(*MockMessenger)
+	numMessages = len(mm.publishedMessages)
+	if numMessages != 1 {
+		t.Errorf("number of published messages was not 1: %d", numMessages)
+	}
+}
+
+func TestMsgPing(t *testing.T) {
+	inittests(t)
+	app := New(cfg)
+	app.amqpClient = &MockMessenger{
+		publishedMessages: make([]MockMessage, 0),
+	}
+	d := amqp.Delivery{
+		RoutingKey: pingKey,
+	}
+	app.msg(d)
+	mm := app.amqpClient.(*MockMessenger)
+	numMessages := len(mm.publishedMessages)
+	if numMessages != 1 {
+		t.Errorf("number of published messages was not 1: %d", numMessages)
+	}
+	msg := mm.publishedMessages[0]
+	if msg.key != pongKey {
+		t.Errorf("routing key was %s instead of %s", msg.key, pongKey)
+	}
+	pong := &ping.Pong{}
+	if err := json.Unmarshal(msg.msg, pong); err != nil {
+		t.Errorf("error unmarshalling message: %s", err)
 	}
 }
 
 func TestMsg(t *testing.T) {
-	if !shouldrun() {
-		return
-	}
 	inittests(t)
-	app := New(cfg)
-	app.db = initdb(t)
-	defer app.db.Close()
-	me, err := os.Hostname()
-	if err != nil {
-		t.Error(err)
+	now := time.Now().Unix()
+	nowstr := fmt.Sprintf("%d", now)
+	testCases := []struct {
+		State        string
+		InvocationID string
+		Message      string
+		Sender       string
+		SenderAddr   string
+		SentOn       string
+	}{
+		{"State", "InvocationID", "Message", "127.0.0.1", "127.0.0.1", nowstr},
+		{"", "InvocationID", "Message", "127.0.0.1", "127.0.0.1", nowstr},
+		{"State", "", "Message", "127.0.0.1", "127.0.0.1", nowstr},
+		{"State", "InvocationID", "Message", "", "0.0.0.0", nowstr},
+		{"State", "InvocationID", "Message", "127.0.0.1", "127.0.0.1", ""},
 	}
-	j := &model.Job{InvocationID: "test-invocation-id"}
-	expected := &messaging.UpdateMessage{
-		Job:     j,
-		State:   "RUNNING",
-		Message: "this is a test",
-		SentOn:  strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10),
-		Sender:  me,
-	}
-	m, err := json.Marshal(expected)
-	if err != nil {
-		t.Error(err)
-	}
-	d := amqp.Delivery{
-		Body:      m,
-		Timestamp: time.Now(),
-	}
-	app.msg(d)
-	rows, err := app.db.Query("select status, message, sent_from, sent_from_hostname, sent_on from job_status_updates where external_id = 'test-invocation-id'")
-	if err != nil {
-		t.Error(err)
-	}
-	defer rows.Close()
-	var (
-		status, message, sentFromHostname string
-		sentOn                            int64
-		sentFrom                          string
-	)
-	for rows.Next() {
-		err = rows.Scan(&status, &message, &sentFrom, &sentFromHostname, &sentOn)
+
+	for _, tc := range testCases {
+		// Set up mock object for the database
+		app := New(cfg)
+		db, mock, err := sqlmock.New()
 		if err != nil {
-			t.Error(err)
+			t.Fatalf("an error '%s' was encountered when creating the mock database", err)
 		}
-		if status != string(expected.State) {
-			t.Errorf("status was %s instead of %s", status, expected.State)
+
+		app.db = db
+
+		// Set up mock object for the amqp stuff
+		app.amqpClient = &MockMessenger{
+			publishedMessages: make([]MockMessage, 0),
 		}
-		if message != expected.Message {
-			t.Errorf("message was %s instead of %s", message, expected.Message)
+
+		u := &messaging.UpdateMessage{
+			State:   messaging.JobState(tc.State),
+			Job:     model.New(cfg),
+			Message: tc.Message,
+			Sender:  tc.Sender,
+			SentOn:  tc.SentOn,
 		}
-		ips, err := net.LookupIP(expected.Sender)
+		u.Job.InvocationID = tc.InvocationID
+
+		body, err := json.Marshal(u)
 		if err != nil {
-			t.Error(err)
+			t.Errorf("error marshalling delivery body: %s", err)
 		}
-		var expectedSentFrom string
-		if len(ips) > 0 {
-			expectedSentFrom = ips[0].String()
-		} else {
-			t.Error("Couldn't get ip address")
+		d := amqp.Delivery{
+			RoutingKey: "not-ping",
+			Body:       body,
 		}
-		if sentFrom != expectedSentFrom {
-			t.Errorf("sentFrom was %s instead of %s", sentFrom, expectedSentFrom)
+
+		var lastInsertID int64
+		result := sqlmock.NewResult(lastInsertID, 1)
+		if tc.Sender == "" {
+			tc.Sender = "0.0.0.0"
 		}
-		if sentFromHostname != me {
-			t.Errorf("sentFromHostname was %s instead of %s", sentFromHostname, me)
+		n := now
+		if tc.SentOn == "" {
+			n = 0
 		}
-		actual := strconv.FormatInt(sentOn, 10)
-		if expected.SentOn != actual {
-			t.Errorf("sentOn was %s instead of %s", actual, expected.SentOn)
+		mock.ExpectExec("INSERT INTO job_status_updates").
+			WithArgs(tc.InvocationID, tc.Message, tc.State, tc.Sender, tc.SenderAddr, n).
+			WillReturnResult(result)
+
+		// make the call
+		app.msg(d)
+
+		if tc.State == "" {
+			continue
 		}
-	}
-	err = rows.Err()
-	if err != nil {
-		t.Error(err)
-	}
-	_, err = app.db.Exec("DELETE FROM job_status_updates")
-	if err != nil {
-		t.Error(err)
+
+		// check the results
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Errorf("unfulfilled expectations inserting job_status_updates")
+		}
+		db.Close()
 	}
 }

--- a/vendor/github.com/DATA-DOG/go-sqlmock/LICENSE
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/LICENSE
@@ -1,0 +1,28 @@
+The three clause BSD license (http://en.wikipedia.org/wiki/BSD_licenses)
+
+Copyright (c) 2013-2016, DATA-DOG team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* The name DataDog.lt may not be used to endorse or promote products
+  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL MICHAEL BOSTOCK BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/DATA-DOG/go-sqlmock/argument.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/argument.go
@@ -1,0 +1,24 @@
+package sqlmock
+
+import "database/sql/driver"
+
+// Argument interface allows to match
+// any argument in specific way when used with
+// ExpectedQuery and ExpectedExec expectations.
+type Argument interface {
+	Match(driver.Value) bool
+}
+
+// AnyArg will return an Argument which can
+// match any kind of arguments.
+//
+// Useful for time.Time or similar kinds of arguments.
+func AnyArg() Argument {
+	return anyArgument{}
+}
+
+type anyArgument struct{}
+
+func (a anyArgument) Match(_ driver.Value) bool {
+	return true
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/driver.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/driver.go
@@ -1,0 +1,78 @@
+package sqlmock
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"sync"
+)
+
+var pool *mockDriver
+
+func init() {
+	pool = &mockDriver{
+		conns: make(map[string]*sqlmock),
+	}
+	sql.Register("sqlmock", pool)
+}
+
+type mockDriver struct {
+	sync.Mutex
+	counter int
+	conns   map[string]*sqlmock
+}
+
+func (d *mockDriver) Open(dsn string) (driver.Conn, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	c, ok := d.conns[dsn]
+	if !ok {
+		return c, fmt.Errorf("expected a connection to be available, but it is not")
+	}
+
+	c.opened++
+	return c, nil
+}
+
+// New creates sqlmock database connection
+// and a mock to manage expectations.
+// Pings db so that all expectations could be
+// asserted.
+func New() (*sql.DB, Sqlmock, error) {
+	pool.Lock()
+	dsn := fmt.Sprintf("sqlmock_db_%d", pool.counter)
+	pool.counter++
+
+	smock := &sqlmock{dsn: dsn, drv: pool, ordered: true}
+	pool.conns[dsn] = smock
+	pool.Unlock()
+
+	return smock.open()
+}
+
+// NewWithDSN creates sqlmock database connection
+// with a specific DSN and a mock to manage expectations.
+// Pings db so that all expectations could be asserted.
+//
+// This method is introduced because of sql abstraction
+// libraries, which do not provide a way to initialize
+// with sql.DB instance. For example GORM library.
+//
+// Note, it will error if attempted to create with an
+// already used dsn
+//
+// It is not recommended to use this method, unless you
+// really need it and there is no other way around.
+func NewWithDSN(dsn string) (*sql.DB, Sqlmock, error) {
+	pool.Lock()
+	if _, ok := pool.conns[dsn]; ok {
+		pool.Unlock()
+		return nil, nil, fmt.Errorf("cannot create a new mock database with the same dsn: %s", dsn)
+	}
+	smock := &sqlmock{dsn: dsn, drv: pool, ordered: true}
+	pool.conns[dsn] = smock
+	pool.Unlock()
+
+	return smock.open()
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/examples/basic/basic.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/examples/basic/basic.go
@@ -1,0 +1,40 @@
+package main
+
+import "database/sql"
+
+func recordStats(db *sql.DB, userID, productID int64) (err error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		switch err {
+		case nil:
+			err = tx.Commit()
+		default:
+			tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.Exec("UPDATE products SET views = views + 1"); err != nil {
+		return
+	}
+	if _, err = tx.Exec("INSERT INTO product_viewers (user_id, product_id) VALUES (?, ?)", userID, productID); err != nil {
+		return
+	}
+	return
+}
+
+func main() {
+	// @NOTE: the real connection is not required for tests
+	db, err := sql.Open("mysql", "root@/blog")
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	if err = recordStats(db, 1 /*some user id*/, 5 /*some product id*/); err != nil {
+		panic(err)
+	}
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/examples/blog/blog.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/examples/blog/blog.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+)
+
+type api struct {
+	db *sql.DB
+}
+
+type post struct {
+	ID    int
+	Title string
+	Body  string
+}
+
+func (a *api) posts(w http.ResponseWriter, r *http.Request) {
+	rows, err := a.db.Query("SELECT id, title, body FROM posts")
+	if err != nil {
+		a.fail(w, "failed to fetch posts: "+err.Error(), 500)
+		return
+	}
+	defer rows.Close()
+
+	var posts []*post
+	for rows.Next() {
+		p := &post{}
+		if err := rows.Scan(&p.ID, &p.Title, &p.Body); err != nil {
+			a.fail(w, "failed to scan post: "+err.Error(), 500)
+			return
+		}
+		posts = append(posts, p)
+	}
+	if rows.Err() != nil {
+		a.fail(w, "failed to read all posts: "+rows.Err().Error(), 500)
+		return
+	}
+
+	data := struct {
+		Posts []*post
+	}{posts}
+
+	a.ok(w, data)
+}
+
+func main() {
+	// @NOTE: the real connection is not required for tests
+	db, err := sql.Open("mysql", "root@/blog")
+	if err != nil {
+		panic(err)
+	}
+	app := &api{db: db}
+	http.HandleFunc("/posts", app.posts)
+	http.ListenAndServe(":8080", nil)
+}
+
+func (a *api) fail(w http.ResponseWriter, msg string, status int) {
+	w.Header().Set("Content-Type", "application/json")
+
+	data := struct {
+		Error string
+	}{Error: msg}
+
+	resp, _ := json.Marshal(data)
+	w.WriteHeader(status)
+	w.Write(resp)
+}
+
+func (a *api) ok(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+
+	resp, err := json.Marshal(data)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		a.fail(w, "oops something evil has happened", 500)
+		return
+	}
+	w.Write(resp)
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/examples/doc.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/examples/doc.go
@@ -1,0 +1,1 @@
+package examples

--- a/vendor/github.com/DATA-DOG/go-sqlmock/examples/orders/orders.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/examples/orders/orders.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/kisielk/sqlstruct"
+)
+
+const ORDER_PENDING = 0
+const ORDER_CANCELLED = 1
+
+type User struct {
+	Id       int     `sql:"id"`
+	Username string  `sql:"username"`
+	Balance  float64 `sql:"balance"`
+}
+
+type Order struct {
+	Id          int     `sql:"id"`
+	Value       float64 `sql:"value"`
+	ReservedFee float64 `sql:"reserved_fee"`
+	Status      int     `sql:"status"`
+}
+
+func cancelOrder(id int, db *sql.DB) (err error) {
+	tx, err := db.Begin()
+	if err != nil {
+		return
+	}
+
+	var order Order
+	var user User
+	sql := fmt.Sprintf(`
+SELECT %s, %s
+FROM orders AS o
+INNER JOIN users AS u ON o.buyer_id = u.id
+WHERE o.id = ?
+FOR UPDATE`,
+		sqlstruct.ColumnsAliased(order, "o"),
+		sqlstruct.ColumnsAliased(user, "u"))
+
+	// fetch order to cancel
+	rows, err := tx.Query(sql, id)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+
+	defer rows.Close()
+	// no rows, nothing to do
+	if !rows.Next() {
+		tx.Rollback()
+		return
+	}
+
+	// read order
+	err = sqlstruct.ScanAliased(&order, rows, "o")
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+
+	// ensure order status
+	if order.Status != ORDER_PENDING {
+		tx.Rollback()
+		return
+	}
+
+	// read user
+	err = sqlstruct.ScanAliased(&user, rows, "u")
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	rows.Close() // manually close before other prepared statements
+
+	// refund order value
+	sql = "UPDATE users SET balance = balance + ? WHERE id = ?"
+	refundStmt, err := tx.Prepare(sql)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	defer refundStmt.Close()
+	_, err = refundStmt.Exec(order.Value+order.ReservedFee, user.Id)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+
+	// update order status
+	order.Status = ORDER_CANCELLED
+	sql = "UPDATE orders SET status = ?, updated = NOW() WHERE id = ?"
+	orderUpdStmt, err := tx.Prepare(sql)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	defer orderUpdStmt.Close()
+	_, err = orderUpdStmt.Exec(order.Status, order.Id)
+	if err != nil {
+		tx.Rollback()
+		return
+	}
+	return tx.Commit()
+}
+
+func main() {
+	// @NOTE: the real connection is not required for tests
+	db, err := sql.Open("mysql", "root:@/orders")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+	err = cancelOrder(1, db)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/expectations.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/expectations.go
@@ -1,0 +1,358 @@
+package sqlmock
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// an expectation interface
+type expectation interface {
+	fulfilled() bool
+	Lock()
+	Unlock()
+	String() string
+}
+
+// common expectation struct
+// satisfies the expectation interface
+type commonExpectation struct {
+	sync.Mutex
+	triggered bool
+	err       error
+}
+
+func (e *commonExpectation) fulfilled() bool {
+	return e.triggered
+}
+
+// ExpectedClose is used to manage *sql.DB.Close expectation
+// returned by *Sqlmock.ExpectClose.
+type ExpectedClose struct {
+	commonExpectation
+}
+
+// WillReturnError allows to set an error for *sql.DB.Close action
+func (e *ExpectedClose) WillReturnError(err error) *ExpectedClose {
+	e.err = err
+	return e
+}
+
+// String returns string representation
+func (e *ExpectedClose) String() string {
+	msg := "ExpectedClose => expecting database Close"
+	if e.err != nil {
+		msg += fmt.Sprintf(", which should return error: %s", e.err)
+	}
+	return msg
+}
+
+// ExpectedBegin is used to manage *sql.DB.Begin expectation
+// returned by *Sqlmock.ExpectBegin.
+type ExpectedBegin struct {
+	commonExpectation
+}
+
+// WillReturnError allows to set an error for *sql.DB.Begin action
+func (e *ExpectedBegin) WillReturnError(err error) *ExpectedBegin {
+	e.err = err
+	return e
+}
+
+// String returns string representation
+func (e *ExpectedBegin) String() string {
+	msg := "ExpectedBegin => expecting database transaction Begin"
+	if e.err != nil {
+		msg += fmt.Sprintf(", which should return error: %s", e.err)
+	}
+	return msg
+}
+
+// ExpectedCommit is used to manage *sql.Tx.Commit expectation
+// returned by *Sqlmock.ExpectCommit.
+type ExpectedCommit struct {
+	commonExpectation
+}
+
+// WillReturnError allows to set an error for *sql.Tx.Close action
+func (e *ExpectedCommit) WillReturnError(err error) *ExpectedCommit {
+	e.err = err
+	return e
+}
+
+// String returns string representation
+func (e *ExpectedCommit) String() string {
+	msg := "ExpectedCommit => expecting transaction Commit"
+	if e.err != nil {
+		msg += fmt.Sprintf(", which should return error: %s", e.err)
+	}
+	return msg
+}
+
+// ExpectedRollback is used to manage *sql.Tx.Rollback expectation
+// returned by *Sqlmock.ExpectRollback.
+type ExpectedRollback struct {
+	commonExpectation
+}
+
+// WillReturnError allows to set an error for *sql.Tx.Rollback action
+func (e *ExpectedRollback) WillReturnError(err error) *ExpectedRollback {
+	e.err = err
+	return e
+}
+
+// String returns string representation
+func (e *ExpectedRollback) String() string {
+	msg := "ExpectedRollback => expecting transaction Rollback"
+	if e.err != nil {
+		msg += fmt.Sprintf(", which should return error: %s", e.err)
+	}
+	return msg
+}
+
+// ExpectedQuery is used to manage *sql.DB.Query, *dql.DB.QueryRow, *sql.Tx.Query,
+// *sql.Tx.QueryRow, *sql.Stmt.Query or *sql.Stmt.QueryRow expectations.
+// Returned by *Sqlmock.ExpectQuery.
+type ExpectedQuery struct {
+	queryBasedExpectation
+	rows driver.Rows
+}
+
+// WithArgs will match given expected args to actual database query arguments.
+// if at least one argument does not match, it will return an error. For specific
+// arguments an sqlmock.Argument interface can be used to match an argument.
+func (e *ExpectedQuery) WithArgs(args ...driver.Value) *ExpectedQuery {
+	e.args = args
+	return e
+}
+
+// WillReturnError allows to set an error for expected database query
+func (e *ExpectedQuery) WillReturnError(err error) *ExpectedQuery {
+	e.err = err
+	return e
+}
+
+// WillReturnRows specifies the set of resulting rows that will be returned
+// by the triggered query
+func (e *ExpectedQuery) WillReturnRows(rows driver.Rows) *ExpectedQuery {
+	e.rows = rows
+	return e
+}
+
+// String returns string representation
+func (e *ExpectedQuery) String() string {
+	msg := "ExpectedQuery => expecting Query or QueryRow which:"
+	msg += "\n  - matches sql: '" + e.sqlRegex.String() + "'"
+
+	if len(e.args) == 0 {
+		msg += "\n  - is without arguments"
+	} else {
+		msg += "\n  - is with arguments:\n"
+		for i, arg := range e.args {
+			msg += fmt.Sprintf("    %d - %+v\n", i, arg)
+		}
+		msg = strings.TrimSpace(msg)
+	}
+
+	if e.rows != nil {
+		msg += "\n  - should return rows:\n"
+		rs, _ := e.rows.(*rows)
+		for i, row := range rs.rows {
+			msg += fmt.Sprintf("    %d - %+v\n", i, row)
+		}
+		msg = strings.TrimSpace(msg)
+	}
+
+	if e.err != nil {
+		msg += fmt.Sprintf("\n  - should return error: %s", e.err)
+	}
+
+	return msg
+}
+
+// ExpectedExec is used to manage *sql.DB.Exec, *sql.Tx.Exec or *sql.Stmt.Exec expectations.
+// Returned by *Sqlmock.ExpectExec.
+type ExpectedExec struct {
+	queryBasedExpectation
+	result driver.Result
+}
+
+// WithArgs will match given expected args to actual database exec operation arguments.
+// if at least one argument does not match, it will return an error. For specific
+// arguments an sqlmock.Argument interface can be used to match an argument.
+func (e *ExpectedExec) WithArgs(args ...driver.Value) *ExpectedExec {
+	e.args = args
+	return e
+}
+
+// WillReturnError allows to set an error for expected database exec action
+func (e *ExpectedExec) WillReturnError(err error) *ExpectedExec {
+	e.err = err
+	return e
+}
+
+// String returns string representation
+func (e *ExpectedExec) String() string {
+	msg := "ExpectedExec => expecting Exec which:"
+	msg += "\n  - matches sql: '" + e.sqlRegex.String() + "'"
+
+	if len(e.args) == 0 {
+		msg += "\n  - is without arguments"
+	} else {
+		msg += "\n  - is with arguments:\n"
+		var margs []string
+		for i, arg := range e.args {
+			margs = append(margs, fmt.Sprintf("    %d - %+v", i, arg))
+		}
+		msg += strings.Join(margs, "\n")
+	}
+
+	if e.result != nil {
+		res, _ := e.result.(*result)
+		msg += "\n  - should return Result having:"
+		msg += fmt.Sprintf("\n      LastInsertId: %d", res.insertID)
+		msg += fmt.Sprintf("\n      RowsAffected: %d", res.rowsAffected)
+		if res.err != nil {
+			msg += fmt.Sprintf("\n      Error: %s", res.err)
+		}
+	}
+
+	if e.err != nil {
+		msg += fmt.Sprintf("\n  - should return error: %s", e.err)
+	}
+
+	return msg
+}
+
+// WillReturnResult arranges for an expected Exec() to return a particular
+// result, there is sqlmock.NewResult(lastInsertID int64, affectedRows int64) method
+// to build a corresponding result. Or if actions needs to be tested against errors
+// sqlmock.NewErrorResult(err error) to return a given error.
+func (e *ExpectedExec) WillReturnResult(result driver.Result) *ExpectedExec {
+	e.result = result
+	return e
+}
+
+// ExpectedPrepare is used to manage *sql.DB.Prepare or *sql.Tx.Prepare expectations.
+// Returned by *Sqlmock.ExpectPrepare.
+type ExpectedPrepare struct {
+	commonExpectation
+	mock      *sqlmock
+	sqlRegex  *regexp.Regexp
+	statement driver.Stmt
+	closeErr  error
+}
+
+// WillReturnError allows to set an error for the expected *sql.DB.Prepare or *sql.Tx.Prepare action.
+func (e *ExpectedPrepare) WillReturnError(err error) *ExpectedPrepare {
+	e.err = err
+	return e
+}
+
+// WillReturnCloseError allows to set an error for this prapared statement Close action
+func (e *ExpectedPrepare) WillReturnCloseError(err error) *ExpectedPrepare {
+	e.closeErr = err
+	return e
+}
+
+// ExpectQuery allows to expect Query() or QueryRow() on this prepared statement.
+// this method is convenient in order to prevent duplicating sql query string matching.
+func (e *ExpectedPrepare) ExpectQuery() *ExpectedQuery {
+	eq := &ExpectedQuery{}
+	eq.sqlRegex = e.sqlRegex
+	e.mock.expected = append(e.mock.expected, eq)
+	return eq
+}
+
+// ExpectExec allows to expect Exec() on this prepared statement.
+// this method is convenient in order to prevent duplicating sql query string matching.
+func (e *ExpectedPrepare) ExpectExec() *ExpectedExec {
+	eq := &ExpectedExec{}
+	eq.sqlRegex = e.sqlRegex
+	e.mock.expected = append(e.mock.expected, eq)
+	return eq
+}
+
+// String returns string representation
+func (e *ExpectedPrepare) String() string {
+	msg := "ExpectedPrepare => expecting Prepare statement which:"
+	msg += "\n  - matches sql: '" + e.sqlRegex.String() + "'"
+
+	if e.err != nil {
+		msg += fmt.Sprintf("\n  - should return error: %s", e.err)
+	}
+
+	if e.closeErr != nil {
+		msg += fmt.Sprintf("\n  - should return error on Close: %s", e.closeErr)
+	}
+
+	return msg
+}
+
+// query based expectation
+// adds a query matching logic
+type queryBasedExpectation struct {
+	commonExpectation
+	sqlRegex *regexp.Regexp
+	args     []driver.Value
+}
+
+func (e *queryBasedExpectation) attemptMatch(sql string, args []driver.Value) (err error) {
+	if !e.queryMatches(sql) {
+		return fmt.Errorf(`could not match sql: "%s" with expected regexp "%s"`, sql, e.sqlRegex.String())
+	}
+
+	// catch panic
+	defer func() {
+		if e := recover(); e != nil {
+			_, ok := e.(error)
+			if !ok {
+				err = fmt.Errorf(e.(string))
+			}
+		}
+	}()
+
+	err = e.argsMatches(args)
+	return
+}
+
+func (e *queryBasedExpectation) queryMatches(sql string) bool {
+	return e.sqlRegex.MatchString(sql)
+}
+
+func (e *queryBasedExpectation) argsMatches(args []driver.Value) error {
+	if nil == e.args {
+		return nil
+	}
+	if len(args) != len(e.args) {
+		return fmt.Errorf("expected %d, but got %d arguments", len(e.args), len(args))
+	}
+	for k, v := range args {
+		// custom argument matcher
+		matcher, ok := e.args[k].(Argument)
+		if ok {
+			if !matcher.Match(v) {
+				return fmt.Errorf("matcher %T could not match %d argument %T - %+v", matcher, k, args[k], args[k])
+			}
+			continue
+		}
+
+		// convert to driver converter
+		darg, err := driver.DefaultParameterConverter.ConvertValue(e.args[k])
+		if err != nil {
+			return fmt.Errorf("could not convert %d argument %T - %+v to driver value: %s", k, e.args[k], e.args[k], err)
+		}
+
+		if !driver.IsValue(darg) {
+			return fmt.Errorf("argument %d: non-subset type %T returned from Value", k, darg)
+		}
+
+		if !reflect.DeepEqual(darg, args[k]) {
+			return fmt.Errorf("argument %d expected [%T - %+v] does not match actual [%T - %+v]", k, darg, darg, args[k], args[k])
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/result.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/result.go
@@ -1,0 +1,39 @@
+package sqlmock
+
+import (
+	"database/sql/driver"
+)
+
+// Result satisfies sql driver Result, which
+// holds last insert id and rows affected
+// by Exec queries
+type result struct {
+	insertID     int64
+	rowsAffected int64
+	err          error
+}
+
+// NewResult creates a new sql driver Result
+// for Exec based query mocks.
+func NewResult(lastInsertID int64, rowsAffected int64) driver.Result {
+	return &result{
+		insertID:     lastInsertID,
+		rowsAffected: rowsAffected,
+	}
+}
+
+// NewErrorResult creates a new sql driver Result
+// which returns an error given for both interface methods
+func NewErrorResult(err error) driver.Result {
+	return &result{
+		err: err,
+	}
+}
+
+func (r *result) LastInsertId() (int64, error) {
+	return r.insertID, r.err
+}
+
+func (r *result) RowsAffected() (int64, error) {
+	return r.rowsAffected, r.err
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/rows.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/rows.go
@@ -1,0 +1,132 @@
+package sqlmock
+
+import (
+	"database/sql/driver"
+	"encoding/csv"
+	"io"
+	"strings"
+)
+
+// CSVColumnParser is a function which converts trimmed csv
+// column string to a []byte representation. currently
+// transforms NULL to nil
+var CSVColumnParser = func(s string) []byte {
+	switch {
+	case strings.ToLower(s) == "null":
+		return nil
+	}
+	return []byte(s)
+}
+
+// Rows interface allows to construct rows
+// which also satisfies database/sql/driver.Rows interface
+type Rows interface {
+	// composed interface, supports sql driver.Rows
+	driver.Rows
+
+	// AddRow composed from database driver.Value slice
+	// return the same instance to perform subsequent actions.
+	// Note that the number of values must match the number
+	// of columns
+	AddRow(columns ...driver.Value) Rows
+
+	// FromCSVString build rows from csv string.
+	// return the same instance to perform subsequent actions.
+	// Note that the number of values must match the number
+	// of columns
+	FromCSVString(s string) Rows
+
+	// RowError allows to set an error
+	// which will be returned when a given
+	// row number is read
+	RowError(row int, err error) Rows
+
+	// CloseError allows to set an error
+	// which will be returned by rows.Close
+	// function.
+	//
+	// The close error will be triggered only in cases
+	// when rows.Next() EOF was not yet reached, that is
+	// a default sql library behavior
+	CloseError(err error) Rows
+}
+
+type rows struct {
+	cols     []string
+	rows     [][]driver.Value
+	pos      int
+	nextErr  map[int]error
+	closeErr error
+}
+
+func (r *rows) Columns() []string {
+	return r.cols
+}
+
+func (r *rows) Close() error {
+	return r.closeErr
+}
+
+// advances to next row
+func (r *rows) Next(dest []driver.Value) error {
+	r.pos++
+	if r.pos > len(r.rows) {
+		return io.EOF // per interface spec
+	}
+
+	for i, col := range r.rows[r.pos-1] {
+		dest[i] = col
+	}
+
+	return r.nextErr[r.pos-1]
+}
+
+// NewRows allows Rows to be created from a
+// sql driver.Value slice or from the CSV string and
+// to be used as sql driver.Rows
+func NewRows(columns []string) Rows {
+	return &rows{cols: columns, nextErr: make(map[int]error)}
+}
+
+func (r *rows) CloseError(err error) Rows {
+	r.closeErr = err
+	return r
+}
+
+func (r *rows) RowError(row int, err error) Rows {
+	r.nextErr[row] = err
+	return r
+}
+
+func (r *rows) AddRow(values ...driver.Value) Rows {
+	if len(values) != len(r.cols) {
+		panic("Expected number of values to match number of columns")
+	}
+
+	row := make([]driver.Value, len(r.cols))
+	for i, v := range values {
+		row[i] = v
+	}
+
+	r.rows = append(r.rows, row)
+	return r
+}
+
+func (r *rows) FromCSVString(s string) Rows {
+	res := strings.NewReader(strings.TrimSpace(s))
+	csvReader := csv.NewReader(res)
+
+	for {
+		res, err := csvReader.Read()
+		if err != nil || res == nil {
+			break
+		}
+
+		row := make([]driver.Value, len(r.cols))
+		for i, v := range res {
+			row[i] = CSVColumnParser(strings.TrimSpace(v))
+		}
+		r.rows = append(r.rows, row)
+	}
+	return r
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/sqlmock.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/sqlmock.go
@@ -1,0 +1,454 @@
+/*
+Package sqlmock is a mock library implementing sql driver. Which has one and only
+purpose - to simulate any sql driver behavior in tests, without needing a real
+database connection. It helps to maintain correct **TDD** workflow.
+
+It does not require any modifications to your source code in order to test
+and mock database operations. Supports concurrency and multiple database mocking.
+
+The driver allows to mock any sql driver method behavior.
+*/
+package sqlmock
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"regexp"
+)
+
+// Sqlmock interface serves to create expectations
+// for any kind of database action in order to mock
+// and test real database behavior.
+type Sqlmock interface {
+
+	// ExpectClose queues an expectation for this database
+	// action to be triggered. the *ExpectedClose allows
+	// to mock database response
+	ExpectClose() *ExpectedClose
+
+	// ExpectationsWereMet checks whether all queued expectations
+	// were met in order. If any of them was not met - an error is returned.
+	ExpectationsWereMet() error
+
+	// ExpectPrepare expects Prepare() to be called with sql query
+	// which match sqlRegexStr given regexp.
+	// the *ExpectedPrepare allows to mock database response.
+	// Note that you may expect Query() or Exec() on the *ExpectedPrepare
+	// statement to prevent repeating sqlRegexStr
+	ExpectPrepare(sqlRegexStr string) *ExpectedPrepare
+
+	// ExpectQuery expects Query() or QueryRow() to be called with sql query
+	// which match sqlRegexStr given regexp.
+	// the *ExpectedQuery allows to mock database response.
+	ExpectQuery(sqlRegexStr string) *ExpectedQuery
+
+	// ExpectExec expects Exec() to be called with sql query
+	// which match sqlRegexStr given regexp.
+	// the *ExpectedExec allows to mock database response
+	ExpectExec(sqlRegexStr string) *ExpectedExec
+
+	// ExpectBegin expects *sql.DB.Begin to be called.
+	// the *ExpectedBegin allows to mock database response
+	ExpectBegin() *ExpectedBegin
+
+	// ExpectCommit expects *sql.Tx.Commit to be called.
+	// the *ExpectedCommit allows to mock database response
+	ExpectCommit() *ExpectedCommit
+
+	// ExpectRollback expects *sql.Tx.Rollback to be called.
+	// the *ExpectedRollback allows to mock database response
+	ExpectRollback() *ExpectedRollback
+
+	// MatchExpectationsInOrder gives an option whether to match all
+	// expectations in the order they were set or not.
+	//
+	// By default it is set to - true. But if you use goroutines
+	// to parallelize your query executation, that option may
+	// be handy.
+	MatchExpectationsInOrder(bool)
+}
+
+type sqlmock struct {
+	ordered bool
+	dsn     string
+	opened  int
+	drv     *mockDriver
+
+	expected []expectation
+}
+
+func (c *sqlmock) open() (*sql.DB, Sqlmock, error) {
+	db, err := sql.Open("sqlmock", c.dsn)
+	if err != nil {
+		return db, c, err
+	}
+	return db, c, db.Ping()
+}
+
+func (c *sqlmock) ExpectClose() *ExpectedClose {
+	e := &ExpectedClose{}
+	c.expected = append(c.expected, e)
+	return e
+}
+
+func (c *sqlmock) MatchExpectationsInOrder(b bool) {
+	c.ordered = b
+}
+
+// Close a mock database driver connection. It may or may not
+// be called depending on the sircumstances, but if it is called
+// there must be an *ExpectedClose expectation satisfied.
+// meets http://golang.org/pkg/database/sql/driver/#Conn interface
+func (c *sqlmock) Close() error {
+	c.drv.Lock()
+	defer c.drv.Unlock()
+
+	c.opened--
+	if c.opened == 0 {
+		delete(c.drv.conns, c.dsn)
+	}
+
+	var expected *ExpectedClose
+	var fulfilled int
+	var ok bool
+	for _, next := range c.expected {
+		next.Lock()
+		if next.fulfilled() {
+			next.Unlock()
+			fulfilled++
+			continue
+		}
+
+		if expected, ok = next.(*ExpectedClose); ok {
+			break
+		}
+
+		next.Unlock()
+		if c.ordered {
+			return fmt.Errorf("call to database Close, was not expected, next expectation is: %s", next)
+		}
+	}
+
+	if expected == nil {
+		msg := "call to database Close was not expected"
+		if fulfilled == len(c.expected) {
+			msg = "all expectations were already fulfilled, " + msg
+		}
+		return fmt.Errorf(msg)
+	}
+
+	expected.triggered = true
+	expected.Unlock()
+	return expected.err
+}
+
+func (c *sqlmock) ExpectationsWereMet() error {
+	for _, e := range c.expected {
+		if !e.fulfilled() {
+			return fmt.Errorf("there is a remaining expectation which was not matched: %s", e)
+		}
+	}
+	return nil
+}
+
+// Begin meets http://golang.org/pkg/database/sql/driver/#Conn interface
+func (c *sqlmock) Begin() (driver.Tx, error) {
+	var expected *ExpectedBegin
+	var ok bool
+	var fulfilled int
+	for _, next := range c.expected {
+		next.Lock()
+		if next.fulfilled() {
+			next.Unlock()
+			fulfilled++
+			continue
+		}
+
+		if expected, ok = next.(*ExpectedBegin); ok {
+			break
+		}
+
+		next.Unlock()
+		if c.ordered {
+			return nil, fmt.Errorf("call to database transaction Begin, was not expected, next expectation is: %s", next)
+		}
+	}
+	if expected == nil {
+		msg := "call to database transaction Begin was not expected"
+		if fulfilled == len(c.expected) {
+			msg = "all expectations were already fulfilled, " + msg
+		}
+		return nil, fmt.Errorf(msg)
+	}
+
+	expected.triggered = true
+	expected.Unlock()
+	return c, expected.err
+}
+
+func (c *sqlmock) ExpectBegin() *ExpectedBegin {
+	e := &ExpectedBegin{}
+	c.expected = append(c.expected, e)
+	return e
+}
+
+// Exec meets http://golang.org/pkg/database/sql/driver/#Execer
+func (c *sqlmock) Exec(query string, args []driver.Value) (res driver.Result, err error) {
+	query = stripQuery(query)
+	var expected *ExpectedExec
+	var fulfilled int
+	var ok bool
+	for _, next := range c.expected {
+		next.Lock()
+		if next.fulfilled() {
+			next.Unlock()
+			fulfilled++
+			continue
+		}
+
+		if c.ordered {
+			if expected, ok = next.(*ExpectedExec); ok {
+				break
+			}
+			next.Unlock()
+			return nil, fmt.Errorf("call to exec query '%s' with args %+v, was not expected, next expectation is: %s", query, args, next)
+		}
+		if exec, ok := next.(*ExpectedExec); ok {
+			if err := exec.attemptMatch(query, args); err == nil {
+				expected = exec
+				break
+			}
+		}
+		next.Unlock()
+	}
+	if expected == nil {
+		msg := "call to exec '%s' query with args %+v was not expected"
+		if fulfilled == len(c.expected) {
+			msg = "all expectations were already fulfilled, " + msg
+		}
+		return nil, fmt.Errorf(msg, query, args)
+	}
+
+	defer expected.Unlock()
+
+	if !expected.queryMatches(query) {
+		return nil, fmt.Errorf("exec query '%s', does not match regex '%s'", query, expected.sqlRegex.String())
+	}
+
+	if err := expected.argsMatches(args); err != nil {
+		return nil, fmt.Errorf("exec query '%s', arguments do not match: %s", query, err)
+	}
+
+	expected.triggered = true
+
+	if expected.err != nil {
+		return nil, expected.err // mocked to return error
+	}
+
+	if expected.result == nil {
+		return nil, fmt.Errorf("exec query '%s' with args %+v, must return a database/sql/driver.result, but it was not set for expectation %T as %+v", query, args, expected, expected)
+	}
+
+	return expected.result, err
+}
+
+func (c *sqlmock) ExpectExec(sqlRegexStr string) *ExpectedExec {
+	e := &ExpectedExec{}
+	e.sqlRegex = regexp.MustCompile(sqlRegexStr)
+	c.expected = append(c.expected, e)
+	return e
+}
+
+// Prepare meets http://golang.org/pkg/database/sql/driver/#Conn interface
+func (c *sqlmock) Prepare(query string) (driver.Stmt, error) {
+	var expected *ExpectedPrepare
+	var fulfilled int
+	var ok bool
+	for _, next := range c.expected {
+		next.Lock()
+		if next.fulfilled() {
+			next.Unlock()
+			fulfilled++
+			continue
+		}
+
+		if expected, ok = next.(*ExpectedPrepare); ok {
+			break
+		}
+
+		next.Unlock()
+		if c.ordered {
+			return nil, fmt.Errorf("call to Prepare statement with query '%s', was not expected, next expectation is: %s", query, next)
+		}
+	}
+
+	query = stripQuery(query)
+	if expected == nil {
+		msg := "call to Prepare '%s' query was not expected"
+		if fulfilled == len(c.expected) {
+			msg = "all expectations were already fulfilled, " + msg
+		}
+		return nil, fmt.Errorf(msg, query)
+	}
+
+	expected.triggered = true
+	expected.Unlock()
+	return &statement{c, query, expected.closeErr}, expected.err
+}
+
+func (c *sqlmock) ExpectPrepare(sqlRegexStr string) *ExpectedPrepare {
+	e := &ExpectedPrepare{sqlRegex: regexp.MustCompile(sqlRegexStr), mock: c}
+	c.expected = append(c.expected, e)
+	return e
+}
+
+// Query meets http://golang.org/pkg/database/sql/driver/#Queryer
+func (c *sqlmock) Query(query string, args []driver.Value) (rw driver.Rows, err error) {
+	query = stripQuery(query)
+	var expected *ExpectedQuery
+	var fulfilled int
+	var ok bool
+	for _, next := range c.expected {
+		next.Lock()
+		if next.fulfilled() {
+			next.Unlock()
+			fulfilled++
+			continue
+		}
+
+		if c.ordered {
+			if expected, ok = next.(*ExpectedQuery); ok {
+				break
+			}
+			next.Unlock()
+			return nil, fmt.Errorf("call to query '%s' with args %+v, was not expected, next expectation is: %s", query, args, next)
+		}
+		if qr, ok := next.(*ExpectedQuery); ok {
+			if err := qr.attemptMatch(query, args); err == nil {
+				expected = qr
+				break
+			}
+		}
+		next.Unlock()
+	}
+
+	if expected == nil {
+		msg := "call to query '%s' with args %+v was not expected"
+		if fulfilled == len(c.expected) {
+			msg = "all expectations were already fulfilled, " + msg
+		}
+		return nil, fmt.Errorf(msg, query, args)
+	}
+
+	defer expected.Unlock()
+
+	if !expected.queryMatches(query) {
+		return nil, fmt.Errorf("query '%s', does not match regex [%s]", query, expected.sqlRegex.String())
+	}
+
+	if err := expected.argsMatches(args); err != nil {
+		return nil, fmt.Errorf("exec query '%s', arguments do not match: %s", query, err)
+	}
+
+	expected.triggered = true
+
+	if expected.err != nil {
+		return nil, expected.err // mocked to return error
+	}
+
+	if expected.rows == nil {
+		return nil, fmt.Errorf("query '%s' with args %+v, must return a database/sql/driver.rows, but it was not set for expectation %T as %+v", query, args, expected, expected)
+	}
+
+	return expected.rows, err
+}
+
+func (c *sqlmock) ExpectQuery(sqlRegexStr string) *ExpectedQuery {
+	e := &ExpectedQuery{}
+	e.sqlRegex = regexp.MustCompile(sqlRegexStr)
+	c.expected = append(c.expected, e)
+	return e
+}
+
+func (c *sqlmock) ExpectCommit() *ExpectedCommit {
+	e := &ExpectedCommit{}
+	c.expected = append(c.expected, e)
+	return e
+}
+
+func (c *sqlmock) ExpectRollback() *ExpectedRollback {
+	e := &ExpectedRollback{}
+	c.expected = append(c.expected, e)
+	return e
+}
+
+// Commit meets http://golang.org/pkg/database/sql/driver/#Tx
+func (c *sqlmock) Commit() error {
+	var expected *ExpectedCommit
+	var fulfilled int
+	var ok bool
+	for _, next := range c.expected {
+		next.Lock()
+		if next.fulfilled() {
+			next.Unlock()
+			fulfilled++
+			continue
+		}
+
+		if expected, ok = next.(*ExpectedCommit); ok {
+			break
+		}
+
+		next.Unlock()
+		if c.ordered {
+			return fmt.Errorf("call to commit transaction, was not expected, next expectation is: %s", next)
+		}
+	}
+	if expected == nil {
+		msg := "call to commit transaction was not expected"
+		if fulfilled == len(c.expected) {
+			msg = "all expectations were already fulfilled, " + msg
+		}
+		return fmt.Errorf(msg)
+	}
+
+	expected.triggered = true
+	expected.Unlock()
+	return expected.err
+}
+
+// Rollback meets http://golang.org/pkg/database/sql/driver/#Tx
+func (c *sqlmock) Rollback() error {
+	var expected *ExpectedRollback
+	var fulfilled int
+	var ok bool
+	for _, next := range c.expected {
+		next.Lock()
+		if next.fulfilled() {
+			next.Unlock()
+			fulfilled++
+			continue
+		}
+
+		if expected, ok = next.(*ExpectedRollback); ok {
+			break
+		}
+
+		next.Unlock()
+		if c.ordered {
+			return fmt.Errorf("call to rollback transaction, was not expected, next expectation is: %s", next)
+		}
+	}
+	if expected == nil {
+		msg := "call to rollback transaction was not expected"
+		if fulfilled == len(c.expected) {
+			msg = "all expectations were already fulfilled, " + msg
+		}
+		return fmt.Errorf(msg)
+	}
+
+	expected.triggered = true
+	expected.Unlock()
+	return expected.err
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/statement.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/statement.go
@@ -1,0 +1,27 @@
+package sqlmock
+
+import (
+	"database/sql/driver"
+)
+
+type statement struct {
+	conn  *sqlmock
+	query string
+	err   error
+}
+
+func (stmt *statement) Close() error {
+	return stmt.err
+}
+
+func (stmt *statement) NumInput() int {
+	return -1
+}
+
+func (stmt *statement) Exec(args []driver.Value) (driver.Result, error) {
+	return stmt.conn.Exec(stmt.query, args)
+}
+
+func (stmt *statement) Query(args []driver.Value) (driver.Rows, error) {
+	return stmt.conn.Query(stmt.query, args)
+}

--- a/vendor/github.com/DATA-DOG/go-sqlmock/util.go
+++ b/vendor/github.com/DATA-DOG/go-sqlmock/util.go
@@ -1,0 +1,13 @@
+package sqlmock
+
+import (
+	"regexp"
+	"strings"
+)
+
+var re = regexp.MustCompile("\\s+")
+
+// strip out new lines and trim spaces
+func stripQuery(q string) (s string) {
+	return strings.TrimSpace(re.ReplaceAllString(q, " "))
+}

--- a/vendor/github.com/kisielk/sqlstruct/LICENSE
+++ b/vendor/github.com/kisielk/sqlstruct/LICENSE
@@ -1,0 +1,20 @@
+Copyright 2012 Kamil Kisiel <kamil@kamilkisiel.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kisielk/sqlstruct/sqlstruct.go
+++ b/vendor/github.com/kisielk/sqlstruct/sqlstruct.go
@@ -1,0 +1,281 @@
+// Copyright 2012 Kamil Kisiel. All rights reserved.
+// Use of this source code is governed by the MIT
+// license which can be found in the LICENSE file.
+
+/*
+Package sqlstruct provides some convenience functions for using structs with
+the Go standard library's database/sql package.
+
+The package matches struct field names to SQL query column names. A field can
+also specify a matching column with "sql" tag, if it's different from field
+name.  Unexported fields or fields marked with `sql:"-"` are ignored, just like
+with "encoding/json" package.
+
+For example:
+
+    type T struct {
+        F1 string
+        F2 string `sql:"field2"`
+        F3 string `sql:"-"`
+    }
+
+    rows, err := db.Query(fmt.Sprintf("SELECT %s FROM tablename", sqlstruct.Columns(T{})))
+    ...
+
+    for rows.Next() {
+    	var t T
+        err = sqlstruct.Scan(&t, rows)
+        ...
+    }
+
+    err = rows.Err() // get any errors encountered during iteration
+
+Aliased tables in a SQL statement may be scanned into a specific structure identified
+by the same alias, using the ColumnsAliased and ScanAliased functions:
+
+    type User struct {
+        Id int `sql:"id"`
+        Username string `sql:"username"`
+        Email string `sql:"address"`
+        Name string `sql:"name"`
+        HomeAddress *Address `sql:"-"`
+    }
+
+    type Address struct {
+        Id int `sql:"id"`
+        City string `sql:"city"`
+        Street string `sql:"address"`
+    }
+
+    ...
+
+    var user User
+    var address Address
+    sql := `
+SELECT %s, %s FROM users AS u
+INNER JOIN address AS a ON a.id = u.address_id
+WHERE u.username = ?
+`
+    sql = fmt.Sprintf(sql, sqlstruct.ColumnsAliased(*user, "u"), sqlstruct.ColumnsAliased(*address, "a"))
+    rows, err := db.Query(sql, "gedi")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer rows.Close()
+    if rows.Next() {
+        err = sqlstruct.ScanAliased(&user, rows, "u")
+        if err != nil {
+            log.Fatal(err)
+        }
+        err = sqlstruct.ScanAliased(&address, rows, "a")
+        if err != nil {
+            log.Fatal(err)
+        }
+        user.HomeAddress = address
+    }
+    fmt.Printf("%+v", *user)
+    // output: "{Id:1 Username:gedi Email:gediminas.morkevicius@gmail.com Name:Gedas HomeAddress:0xc21001f570}"
+    fmt.Printf("%+v", *user.HomeAddress)
+    // output: "{Id:2 City:Vilnius Street:Plento 34}"
+
+*/
+package sqlstruct
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// NameMapper is the function used to convert struct fields which do not have sql tags
+// into database column names.
+//
+// The default mapper converts field names to lower case. If instead you would prefer
+// field names converted to snake case, simply assign sqlstruct.ToSnakeCase to the variable:
+//
+//		sqlstruct.NameMapper = sqlstruct.ToSnakeCase
+//
+// Alternatively for a custom mapping, any func(string) string can be used instead.
+var NameMapper func(string) string = strings.ToLower
+
+// A cache of fieldInfos to save reflecting every time. Inspried by encoding/xml
+var finfos map[reflect.Type]fieldInfo
+var finfoLock sync.RWMutex
+
+// TagName is the name of the tag to use on struct fields
+var TagName = "sql"
+
+// fieldInfo is a mapping of field tag values to their indices
+type fieldInfo map[string][]int
+
+func init() {
+	finfos = make(map[reflect.Type]fieldInfo)
+}
+
+// Rows defines the interface of types that are scannable with the Scan function.
+// It is implemented by the sql.Rows type from the standard library
+type Rows interface {
+	Scan(...interface{}) error
+	Columns() ([]string, error)
+}
+
+// getFieldInfo creates a fieldInfo for the provided type. Fields that are not tagged
+// with the "sql" tag and unexported fields are not included.
+func getFieldInfo(typ reflect.Type) fieldInfo {
+	finfoLock.RLock()
+	finfo, ok := finfos[typ]
+	finfoLock.RUnlock()
+	if ok {
+		return finfo
+	}
+
+	finfo = make(fieldInfo)
+
+	n := typ.NumField()
+	for i := 0; i < n; i++ {
+		f := typ.Field(i)
+		tag := f.Tag.Get(TagName)
+
+		// Skip unexported fields or fields marked with "-"
+		if f.PkgPath != "" || tag == "-" {
+			continue
+		}
+
+		// Handle embedded structs
+		if f.Anonymous && f.Type.Kind() == reflect.Struct {
+			for k, v := range getFieldInfo(f.Type) {
+				finfo[k] = append([]int{i}, v...)
+			}
+			continue
+		}
+
+		// Use field name for untagged fields
+		if tag == "" {
+			tag = f.Name
+		}
+		tag = NameMapper(tag)
+
+		finfo[tag] = []int{i}
+	}
+
+	finfoLock.Lock()
+	finfos[typ] = finfo
+	finfoLock.Unlock()
+
+	return finfo
+}
+
+// Scan scans the next row from rows in to a struct pointed to by dest. The struct type
+// should have exported fields tagged with the "sql" tag. Columns from row which are not
+// mapped to any struct fields are ignored. Struct fields which have no matching column
+// in the result set are left unchanged.
+func Scan(dest interface{}, rows Rows) error {
+	return doScan(dest, rows, "")
+}
+
+// ScanAliased works like scan, except that it expects the results in the query to be
+// prefixed by the given alias.
+//
+// For example, if scanning to a field named "name" with an alias of "user" it will
+// expect to find the result in a column named "user_name".
+//
+// See ColumnAliased for a convenient way to generate these queries.
+func ScanAliased(dest interface{}, rows Rows, alias string) error {
+	return doScan(dest, rows, alias)
+}
+
+// Columns returns a string containing a sorted, comma-separated list of column names as
+// defined by the type s. s must be a struct that has exported fields tagged with the "sql" tag.
+func Columns(s interface{}) string {
+	return strings.Join(cols(s), ", ")
+}
+
+// ColumnsAliased works like Columns except it prefixes the resulting column name with the
+// given alias.
+//
+// For each field in the given struct it will generate a statement like:
+//    alias.field AS alias_field
+//
+// It is intended to be used in conjunction with the ScanAliased function.
+func ColumnsAliased(s interface{}, alias string) string {
+	names := cols(s)
+	aliased := make([]string, 0, len(names))
+	for _, n := range names {
+		aliased = append(aliased, alias+"."+n+" AS "+alias+"_"+n)
+	}
+	return strings.Join(aliased, ", ")
+}
+
+func cols(s interface{}) []string {
+	v := reflect.ValueOf(s)
+	fields := getFieldInfo(v.Type())
+
+	names := make([]string, 0, len(fields))
+	for f := range fields {
+		names = append(names, f)
+	}
+
+	sort.Strings(names)
+	return names
+}
+
+func doScan(dest interface{}, rows Rows, alias string) error {
+	destv := reflect.ValueOf(dest)
+	typ := destv.Type()
+
+	if typ.Kind() != reflect.Ptr || typ.Elem().Kind() != reflect.Struct {
+		panic(fmt.Errorf("dest must be pointer to struct; got %T", destv))
+	}
+	fieldInfo := getFieldInfo(typ.Elem())
+
+	elem := destv.Elem()
+	var values []interface{}
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+
+	for _, name := range cols {
+		if len(alias) > 0 {
+			name = strings.Replace(name, alias+"_", "", 1)
+		}
+		idx, ok := fieldInfo[strings.ToLower(name)]
+		var v interface{}
+		if !ok {
+			// There is no field mapped to this column so we discard it
+			v = &sql.RawBytes{}
+		} else {
+			v = elem.FieldByIndex(idx).Addr().Interface()
+		}
+		values = append(values, v)
+	}
+
+	return rows.Scan(values...)
+}
+
+// ToSnakeCase converts a string to snake case, words separated with underscores.
+// It's intended to be used with NameMapper to map struct field names to snake case database fields.
+func ToSnakeCase(src string) string {
+	thisUpper := false
+	prevUpper := false
+
+	buf := bytes.NewBufferString("")
+	for i, v := range src {
+		if v >= 'A' && v <= 'Z' {
+			thisUpper = true
+		} else {
+			thisUpper = false
+		}
+		if i > 0 && thisUpper && !prevUpper {
+			buf.WriteRune('_')
+		}
+		prevUpper = thisUpper
+		buf.WriteRune(v)
+	}
+	return strings.ToLower(buf.String())
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -2,6 +2,14 @@
 	"version": 0,
 	"dependencies": [
 		{
+			"importpath": "github.com/DATA-DOG/go-sqlmock",
+			"repository": "https://github.com/DATA-DOG/go-sqlmock",
+			"vcs": "git",
+			"revision": "05f39e9110c0ed1ec1834d06004693026a4d24f1",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/armon/consul-api",
 			"repository": "https://github.com/armon/consul-api",
 			"vcs": "git",
@@ -98,6 +106,14 @@
 			"repository": "https://github.com/hashicorp/hcl",
 			"vcs": "git",
 			"revision": "baeb59c710717b06aac1dbe2270e8192ec593244",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/kisielk/sqlstruct",
+			"repository": "https://github.com/kisielk/sqlstruct",
+			"vcs": "git",
+			"revision": "648daed35d49dac24a4bff253b190a80da3ab6a5",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Adds more test coverage to job-status-recorder. Uses sqlmock and a mocked up AMQP client to check the code.

Also catches a issue where pongs are marshalled as JSON.
